### PR TITLE
Review round 2

### DIFF
--- a/transport/src/behaviour/base.rs
+++ b/transport/src/behaviour/base.rs
@@ -452,7 +452,7 @@ impl BaseBehaviour {
             #[cfg(feature = "metrics")]
             ONGOING_QUERIES.dec();
             return Some(ToSwarm::Dial {
-                opts: DialOpts::peer_id(peer_id).condition(PeerCondition::NotDialing).build(),
+                opts: DialOpts::peer_id(peer_id).condition(PeerCondition::NotDialing).build(), // Usually, the default of `DisconnectedAndNotDialing` is good enough unless you want to explicitly allow duplicated connections in case you already have one.
             });
         }
         None

--- a/transport/src/behaviour/wrapped.rs
+++ b/transport/src/behaviour/wrapped.rs
@@ -130,9 +130,7 @@ where
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
         self.inner().on_swarm_event(event);
-        for ev in self.wrapper.on_swarm_event(event) {
-            self.pending_events.push_back(ev)
-        }
+        self.pending_events.extend(self.wrapper.on_swarm_event(event));
     }
 
     fn on_connection_handler_event(

--- a/transport/src/bin/bootnode.rs
+++ b/transport/src/bin/bootnode.rs
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
         .with_dns()?
         .with_behaviour(behaviour)
         .expect("infallible")
-        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(120)))
+        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(120))) // Suprisingly long but in itself not harmful esp. with the use of QUIC which reuses a single socket.
         .build();
     for listen_addr in listen_addrs {
         log::info!("Listening on {}", listen_addr);
@@ -118,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
         swarm.add_external_address(public_addr);
     }
 
-    swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
+    swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server)); // Redundant if you are setting an external address.
 
     // Connect to other boot nodes
     for BootNode { peer_id, address } in cli
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
     {
         log::info!("Connecting to boot node {peer_id} at {address}");
         swarm.behaviour_mut().allow.allow_peer(peer_id);
-        swarm.behaviour_mut().kademlia.add_address(&peer_id, address.clone());
+        swarm.behaviour_mut().kademlia.add_address(&peer_id, address.clone()); // This is redundant if you are dialing the peer. We will automatically add every peer to the KAD table if we successfully dialed them and they speak the same KAD protocol.
         swarm.dial(peer_id)?;
     }
 


### PR DESCRIPTION
I've had a look through the codebase again. Left a few minor comments but otherwise this looks really good!

## Tests

I'd maybe recommend is adding some (unit) tests now. You've done all the leg-work of creating your own `NetworkBehaviour` so it should be pretty easy to write some tests using https://docs.rs/libp2p-swarm-test/latest/libp2p_swarm_test/

For reference, you can look at the tests of the identify protocol: https://github.com/libp2p/rust-libp2p/blob/master/protocols/identify/tests/smoke.rs

Using the ephemeral swarm and its utility methods, for example could very easily test the behaviour of:

- Attempting to send message to Swarm
- Initiate a DHT lookup because the peer is unknown
- Connect to it
- Sending message

## Protobuf

I couldn't compile the code because it requires `protoc`. `rust-libp2p` uses protocol buffers internally but in order to not rely on `protoc`, we have migrated all our uses to https://github.com/tafia/quick-protobuf. It works well for `rust-libp2p` with all the generated code being checked into source-control. Less macro magic, better compile times and auditability! You might want to give it a look!

## Rust code

Rust code looks very good too! A few things that I've noticed:

- You could activate clippy's `manual-let-else` lint to get rid of a few uses of `match`: https://rust-lang.github.io/rust-clippy/master/index.html#/manual_let_else
- For reference, these are the lints that `rust-libp2p` uses on top of the regular clippy settings: https://github.com/libp2p/rust-libp2p/blob/38f8f21451be8bce45f14a05a048b53fd4481111/Cargo.toml#L141-L148