### PR TITLE
Drop empty query messages

### DIFF
--- a/crates/assignments/tests/test_building.rs
+++ b/crates/assignments/tests/test_building.rs
@@ -59,8 +59,7 @@ fn test_building() {
 
 #[cfg(feature = "builder")]
 fn assert_file_equals(filename: &str, bytes: Vec<u8>) {
-    use std::fs;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
 
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests");

--- a/crates/contract-client/src/client.rs
+++ b/crates/contract-client/src/client.rs
@@ -7,10 +7,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ethers::types::H160;
 use ethers::{
     prelude::{BlockId, Bytes, Middleware, Multicall, Provider},
-    types::BlockNumber,
+    types::{BlockNumber, H160},
 };
 use libp2p::futures::Stream;
 use num_rational::Ratio;

--- a/crates/messages/src/assignments.rs
+++ b/crates/messages/src/assignments.rs
@@ -21,8 +21,7 @@ use prost::bytes::Bytes;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "assignment_reader")]
 use serde_json::Value;
-use serde_with::base64::Base64;
-use serde_with::serde_as;
+use serde_with::{base64::Base64, serde_as};
 #[cfg(feature = "assignment_reader")]
 use sha2::Digest;
 #[cfg(feature = "assignment_reader")]

--- a/crates/transport/src/actors/worker.rs
+++ b/crates/transport/src/actors/worker.rs
@@ -133,11 +133,16 @@ impl WorkerBehaviour {
         query: Query,
         resp_chan: ResponseChannel<QueryResult>,
     ) -> Option<WorkerEvent> {
-        Some(WorkerEvent::Query {
-            peer_id,
-            query,
-            resp_chan,
-        })
+        // Drop empty messages
+        if query == Query::default() {
+            None
+        } else {
+            Some(WorkerEvent::Query {
+                peer_id,
+                query,
+                resp_chan,
+            })
+        }
     }
 
     pub fn send_query_result(


### PR DESCRIPTION
It doesn't make sense to process queries decoded from empty messages. We can skip passing them to the worker controller and validating signatures.