### PR TITLE
Deprecate worker -> chunks map

### DIFF
--- a/crates/assignments/schema/assignment.fbs
+++ b/crates/assignments/schema/assignment.fbs
@@ -16,10 +16,7 @@ enum WorkerStatus: byte {
 table WorkerAssignment {
   worker_id: WorkerId (required);  // sorted by parsed PeerId
 
-  // TODO: use Elias-Fano encoding to compress this sequence ~4 times.
-  // This field takes about 85% of the entire file's length, but
-  // provides easy access for the reader
-  chunks: [Chunk] (required);
+  chunks: [Chunk] (deprecated);
 
   status: WorkerStatus;
   encrypted_headers: EncryptedHeaders;

--- a/crates/assignments/schema/gen/assignment_generated.rs
+++ b/crates/assignments/schema/gen/assignment_generated.rs
@@ -346,11 +346,11 @@ impl<'a> WorkerAssignment<'a> {
     unsafe { self._tab.get::<WorkerId>(WorkerAssignment::VT_WORKER_ID, None).unwrap()}
   }
   #[inline]
-  pub fn chunks(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Chunk<'a>>> {
+  pub fn chunks(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Chunk<'a>>>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Chunk>>>>(WorkerAssignment::VT_CHUNKS, None).unwrap()}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Chunk>>>>(WorkerAssignment::VT_CHUNKS, None)}
   }
   #[inline]
   pub fn status(&self) -> WorkerStatus {
@@ -376,7 +376,7 @@ impl flatbuffers::Verifiable for WorkerAssignment<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<WorkerId>("worker_id", Self::VT_WORKER_ID, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Chunk>>>>("chunks", Self::VT_CHUNKS, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Chunk>>>>("chunks", Self::VT_CHUNKS, false)?
      .visit_field::<WorkerStatus>("status", Self::VT_STATUS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<EncryptedHeaders>>("encrypted_headers", Self::VT_ENCRYPTED_HEADERS, false)?
      .finish();
@@ -394,7 +394,7 @@ impl<'a> Default for WorkerAssignmentArgs<'a> {
   fn default() -> Self {
     WorkerAssignmentArgs {
       worker_id: None, // required field
-      chunks: None, // required field
+      chunks: None,
       status: WorkerStatus::Ok,
       encrypted_headers: None,
     }
@@ -434,7 +434,6 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> WorkerAssignmentBuilder<'a, 'b,
   pub fn finish(self) -> flatbuffers::WIPOffset<WorkerAssignment<'a>> {
     let o = self.fbb_.end_table(self.start_);
     self.fbb_.required(o, WorkerAssignment::VT_WORKER_ID,"worker_id");
-    self.fbb_.required(o, WorkerAssignment::VT_CHUNKS,"chunks");
     flatbuffers::WIPOffset::new(o.value())
   }
 }

--- a/crates/assignments/tests/test_reading.rs
+++ b/crates/assignments/tests/test_reading.rs
@@ -15,7 +15,7 @@ fn test_get_worker() {
 
     assert_eq!(assignment.get_worker_id(0).unwrap(), peer_id);
 
-    let worker = assignment.get_worker(peer_id).unwrap();
+    let worker = assignment.get_worker(&peer_id).unwrap();
     let headers = worker.decrypt_headers(&keypair).unwrap();
     assert_eq!(
         headers,
@@ -29,10 +29,10 @@ fn test_get_worker() {
     );
     assert_eq!(worker.status(), sqd_assignments::WorkerStatus::Ok);
 
-    let chunks = worker.chunks();
+    let chunks = worker.iter_chunks().collect::<Vec<_>>();
     assert_eq!(chunks.len(), 2);
-    assert_eq!(chunks.get(0).id(), "0221000000/0221000000-0221000649-BQJdx");
-    assert_eq!(chunks.get(1).id(), "0221000000/0221000650-0221001549-AuRE1");
+    assert_eq!(chunks[0].id(), "0221000000/0221000000-0221000649-BQJdx");
+    assert_eq!(chunks[1].id(), "0221000000/0221000650-0221001549-AuRE1");
 }
 
 #[cfg(feature = "reader")]

--- a/crates/messages/src/assignments.rs
+++ b/crates/messages/src/assignments.rs
@@ -122,6 +122,7 @@ pub struct Assignment {
 pub struct NetworkAssignment {
     pub url: String,
     pub fb_url: Option<String>,
+    pub fb_url_v1: Option<String>,
     pub id: String,
     pub effective_from: u64,
 }


### PR DESCRIPTION
It takes almost half of the compressed assignment file but is only used by each worker once to list all its chunks
I propose to remove this map and build it on demand from the "chunk -> workers" map.